### PR TITLE
Fix connect to peers loop

### DIFF
--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -29,6 +29,7 @@ namespace Neo.Network
 
         public const uint ProtocolVersion = 0;
         private const int ConnectedMax = 10;
+        private const int DesiredAvailablePeers = (int)(ConnectedMax * 1.5);
         private const int UnconnectedMax = 1000;
         public const int MemoryPoolSize = 50000;
         internal static readonly TimeSpan HashesExpiration = TimeSpan.FromSeconds(30);
@@ -277,13 +278,15 @@ namespace Neo.Network
 
         private void ConnectToPeersLoop()
         {
+            List<Task> tasksList = new List<Task>();
+            DateTime lastSufficientPeersTimestamp = DateTime.UtcNow;
+
             while (!cancellationTokenSource.IsCancellationRequested)
             {
                 int connectedCount = connectedPeers.Count;
                 int unconnectedCount = unconnectedPeers.Count;
                 if (connectedCount < ConnectedMax)
                 {
-                    Task[] tasks = { };
                     if (unconnectedCount > 0)
                     {
                         IPEndPoint[] endpoints;
@@ -291,24 +294,61 @@ namespace Neo.Network
                         {
                             endpoints = unconnectedPeers.Take(ConnectedMax - connectedCount).ToArray();
                         }
-                        tasks = endpoints.Select(p => ConnectToPeerAsync(p)).ToArray();
+                        tasksList.AddRange(endpoints.Select(p => ConnectToPeerAsync(p)));
                     }
-                    else if (connectedCount > 0)
+
+                    if (connectedCount > 0)
                     {
-                        lock (connectedPeers)
+                        if (unconnectedCount + connectedCount < DesiredAvailablePeers)
                         {
-                            foreach (RemoteNode node in connectedPeers)
-                                node.RequestPeers();
+                            lock (connectedPeers)
+                            {
+                                foreach (RemoteNode node in connectedPeers)
+                                    node.RequestPeers();
+                            }
+
+                            if (lastSufficientPeersTimestamp < DateTime.UtcNow.AddSeconds(-180))
+                            {
+                                Random rand = new Random();
+                                tasksList.AddRange(Settings.Default.SeedList
+                                    .OrderBy(p => rand.Next()).Take(2)
+                                    .OfType<string>().Select(p => p.Split(':'))
+                                    .Select(p => ConnectToPeerAsync(p[0], int.Parse(p[1]))));
+                                
+                                // Reset this so we try to get more peers from the seed nodes before trying to connect
+                                // to seed nodes again.
+                                lastSufficientPeersTimestamp = DateTime.UtcNow;
+                            }
+                        }
+                        else
+                        {
+                            lastSufficientPeersTimestamp = DateTime.UtcNow;
                         }
                     }
                     else
                     {
                         Random rand = new Random();
-                        tasks = Settings.Default.SeedList.OrderBy(p => rand.Next()).Take(5).OfType<string>().Select(p => p.Split(':')).Select(p => ConnectToPeerAsync(p[0], int.Parse(p[1]))).ToArray();
+                        tasksList.AddRange(Settings.Default.SeedList
+                            .OrderBy(p => rand.Next()).Take(5)
+                            .OfType<string>().Select(p => p.Split(':'))
+                            .Select(p => ConnectToPeerAsync(p[0], int.Parse(p[1]))));
+			// Reset this since we have connected to seed nodes.
+                        lastSufficientPeersTimestamp = DateTime.UtcNow;
                     }
+                    
                     try
                     {
-                        Task.WaitAll(tasks, cancellationTokenSource.Token);
+                        var tasksArray = tasksList.ToArray();
+                        Task.WaitAny(tasksArray, 5000, cancellationTokenSource.Token);
+
+                        foreach (var task in tasksArray)
+                        {
+                            if (!task.IsCanceled && !task.IsCompleted && !task.IsFaulted) continue;
+                            
+                            // Clean-up task no longer running.
+                            tasksList.Remove(task);
+                            task.Dispose();
+                        }
                     }
                     catch (OperationCanceledException)
                     {

--- a/neo/Network/LocalNode.cs
+++ b/neo/Network/LocalNode.cs
@@ -220,14 +220,14 @@ namespace Neo.Network
         private static void CheckMemPool()
         {
             if (mem_pool.Count <= MemoryPoolSize) return;
-            
+
             UInt256[] hashes = mem_pool.Values.AsParallel()
                 .OrderBy(p => p.NetworkFee / p.Size)
                 .ThenBy(p => new BigInteger(p.Hash.ToArray()))
                 .Take(mem_pool.Count - MemoryPoolSize)
                 .Select(p => p.Hash)
                 .ToArray();
-            
+
             foreach (UInt256 hash in hashes)
                 mem_pool.Remove(hash);
         }
@@ -303,7 +303,8 @@ namespace Neo.Network
                     }
                     else
                     {
-                        tasks = Settings.Default.SeedList.OfType<string>().Select(p => p.Split(':')).Select(p => ConnectToPeerAsync(p[0], int.Parse(p[1]))).ToArray();
+                        Random rand = new Random();
+                        tasks = Settings.Default.SeedList.OrderBy(p => rand.Next()).Take(5).OfType<string>().Select(p => p.Split(':')).Select(p => ConnectToPeerAsync(p[0], int.Parse(p[1]))).ToArray();
                     }
                     try
                     {


### PR DESCRIPTION
When running several of Aphelion Neo nodes, I experienced issues with the peering behaviour and traced the issues back to issues in the ConnectToPeersLoop implementation. Before this change the code would only try to add more peers to its list of unconnectedPeers if it lost ALL of its currently connected peers. This is definitely not desired behaviour if one wants a Node to stay connected to the network all the time. These changes ensure that there are enough peers in the unconnected peers list to stay connected to the desired amount of peers.

Also, this fixes what I consider a bug, that Task.WaitAll was being used before the loop would continue to connect to other peers. The effect is that a node would have to lose its connections to all peers before trying to reconnect to other peers in its set of unconnectedPeers. This fixes that by using Tasks.WaitAny so that if one task completes it will re-evaluate if it should connect to an additional peer in a relatively short amount of time.

FYI: unrelated to these changes the code that handles transaction verifications has a problem where it can redundantly trigger verifications; when connected to more peers, that problem can be compounded. I'll put out a separate pull request that fixes that problem, because with this fix without that issue fixed; it can lead to other issues unless running on a powerful machine with a high number of processors.