### PR TITLE
 Ensure ConnectToPeersLoop won't connect to the same node twice. 

### DIFF
--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs
@@ -142,6 +142,8 @@ namespace Neo.Implementations.Blockchains.LevelDB
 
         public void AddBlockDirectly(Block block)
         {
+            if (block.Index != Height + 1)
+                throw new InvalidOperationException();
             if (block.Index == header_index.Count)
             {
                 WriteBatch batch = new WriteBatch();

--- a/neo/SmartContract/StateReader.cs
+++ b/neo/SmartContract/StateReader.cs
@@ -482,8 +482,10 @@ namespace Neo.SmartContract
         {
             UInt160 hash = new UInt160(engine.EvaluationStack.Pop().GetByteArray());
             ContractState contract = Contracts.TryGet(hash);
-            if (contract == null) return false;
-            engine.EvaluationStack.Push(StackItem.FromInterface(contract));
+            if (contract == null)
+                engine.EvaluationStack.Push(new byte[0]);
+            else
+                engine.EvaluationStack.Push(StackItem.FromInterface(contract));
             return true;
         }
 


### PR DESCRIPTION
These changes remove the possibility of connecting to the same node twice.